### PR TITLE
Add Alpha Vantage key rotation and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ wrangler dev
 
 Set secrets:
 ```bash
-wrangler secret put ALPHA_VANTAGE_KEY
+# One or more comma-separated Alpha Vantage keys for rotation
+wrangler secret put ALPHA_VANTAGE_KEYS
 # optional:
 wrangler secret put FMP_KEY
 wrangler secret put OPENAI_API_KEY
@@ -37,6 +38,7 @@ wrangler secret put OPTIONS_API_KEY
 Edit `src/config.ts` to change the universe, weights, and thresholds.
 
 ## Notes
-- First-time runs will cache OHLCV in KV for 24h to respect Alpha Vantage limits.
+- OHLCV responses are cached in memory and KV for 24h to respect Alpha Vantage limits.
+- Multiple Alpha Vantage API keys are rotated automatically.
 - Indicators are computed locally to minimize API calls.
 - Options checks are stubbed with an interface; plug your provider later.

--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,13 +1,22 @@
 
 import { cachedGetJSON } from '../store/kvCache';
 
+let keyIdx = 0;
+function nextKey(env: any): string {
+  const raw = env.ALPHA_VANTAGE_KEYS || env.ALPHA_VANTAGE_KEY;
+  const keys = typeof raw === 'string' ? raw.split(',').map((k) => k.trim()).filter(Boolean) : [];
+  if (keys.length === 0) throw new Error('ALPHA_VANTAGE_KEY not set');
+  const k = keys[keyIdx % keys.length];
+  keyIdx += 1;
+  return k;
+}
+
 export async function getDailyAdjusted(env: any, symbol: string) {
-  const key = env.ALPHA_VANTAGE_KEY;
-  if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
+  const key = nextKey(env);
   const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
-    const res = await fetch(url, { cf: { cacheTtl: 0 } });
+    const res = await fetch(url, { cf: { cacheTtl: 3600 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
     const json = await res.json();
     return json;

--- a/src/store/kvCache.ts
+++ b/src/store/kvCache.ts
@@ -1,13 +1,24 @@
 
+const memCache = new Map<string, { exp: number; data: any }>();
+
 export async function cachedGetJSON(
   kv: KVNamespace,
   key: string,
   ttlSeconds: number,
   loader: () => Promise<any>,
 ) {
+  const now = Date.now();
+  const mem = memCache.get(key);
+  if (mem && mem.exp > now) return mem.data;
+
   const cached = await kv.get(key, { type: 'json' });
-  if (cached) return cached;
+  if (cached) {
+    memCache.set(key, { exp: now + ttlSeconds * 1000, data: cached });
+    return cached;
+  }
+
   const data = await loader();
+  memCache.set(key, { exp: now + ttlSeconds * 1000, data });
   await kv.put(key, JSON.stringify(data), { expirationTtl: ttlSeconds });
   return data;
 }


### PR DESCRIPTION
## Summary
- rotate through multiple Alpha Vantage API keys to spread requests
- add in-memory cache layer for API responses
- document API key rotation and caching usage

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68beb9db9ab88332a45a574839ad77ee