### PR TITLE
Use cache binding for AlphaVantage provider

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -6,7 +6,7 @@ export async function getDailyAdjusted(env: any, symbol: string) {
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
   const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
   const cacheKey = `av:daily:${symbol}`;
-  return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
+  return cachedGetJSON(env.CACHE, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
     const json = await res.json();


### PR DESCRIPTION
## Summary
- use the `CACHE` KV binding for AlphaVantage caching

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_b_68bebdd760b48332b069e84d461d9266