### PR TITLE
Use full Alpha Vantage output size for daily data

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -4,7 +4,7 @@ import { cachedGetJSON } from '../store/kvCache';
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=full`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });


### PR DESCRIPTION
## Summary
- request full Alpha Vantage daily history so enough bars are returned

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68bec1a725108332b07e9eddb39bc962