### PR TITLE
chore: restore KV namespace ID

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,7 +4,7 @@ main = "src/index.ts"
 compatibility_date = "2025-09-07"
 
 kv_namespaces = [
-  { binding = "leapspicker", id = "00000000000000000000000000000000", preview_id = "11111111111111111111111111111111" }
+  { binding = "leapspicker", id = "41a32fe24b79414f933dfa1be849cdb0", preview_id = "11111111111111111111111111111111" }
 ]
 
 [triggers]


### PR DESCRIPTION
## Summary
- restore real KV namespace ID in wrangler configuration

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file, due to config migration)*

------
https://chatgpt.com/codex/tasks/task_b_68bec5e2502c8332a3d18f42705c35db