### PR TITLE
Fail fast on missing Alpha Vantage API key and expose filter diagnostics

### DIFF
--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -5,13 +5,22 @@ import { getFundamentals, deriveQualityMetrics } from '../providers/fundamentals
 import { scoreCandidate, EquityMetrics } from '../metrics/scoring';
 import { config } from '../config';
 
-export async function runEquityScreen(env: any, symbols: string[]) {
+export async function runEquityScreen(env: any, symbols: string[]): Promise<{
+  results: any[];
+  diagnostics: { symbol: string; reason: string }[];
+}> {
   const out: any[] = [];
+  const diagnostics: { symbol: string; reason: string }[] = [];
   for (const symbol of symbols) {
     try {
       const json = await getDailyAdjusted(env, symbol);
       const closes = extractCloses(json);
-      if (closes.length < 220) continue;
+      if (closes.length < 220) {
+        const reason = 'insufficient price history';
+        console.log(`${symbol} rejected: ${reason}`);
+        diagnostics.push({ symbol, reason });
+        continue;
+      }
       const price = closes[closes.length - 1];
       const sma50 = sma(closes, 50)[closes.length - 1];
       const sma200Arr = sma(closes, 200);
@@ -24,19 +33,45 @@ export async function runEquityScreen(env: any, symbols: string[]) {
       const mom12m2m = momentum(closes);
 
       // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
+      if (!(price > sma200)) {
+        const reason = `price ${price.toFixed(2)} <= SMA200 ${sma200.toFixed(2)}`;
+        console.log(`${symbol} rejected: ${reason}`);
+        diagnostics.push({ symbol, reason });
+        continue;
+      }
+      if (!(sma200Slope > 0)) {
+        const reason = 'SMA200 slope not positive';
+        console.log(`${symbol} rejected: ${reason}`);
+        diagnostics.push({ symbol, reason });
+        continue;
+      }
+      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) {
+        const reason = `RSI14 ${rsi14.toFixed(2)} outside [${config.thresholds.rsiMin}, ${config.thresholds.rsiMax}]`;
+        console.log(`${symbol} rejected: ${reason}`);
+        diagnostics.push({ symbol, reason });
+        continue;
+      }
+      if (!(mdd1y >= config.thresholds.maxDrawdown)) {
+        const reason = `max drawdown ${mdd1y.toFixed(2)} < ${config.thresholds.maxDrawdown}`;
+        console.log(`${symbol} rejected: ${reason}`);
+        diagnostics.push({ symbol, reason });
+        continue;
+      }
 
       // Fundamentals (optional)
       const funda = await getFundamentals(env, symbol);
       const q = deriveQualityMetrics(funda);
 
       const eq: EquityMetrics = {
-        symbol, price, sma50, sma200, sma200Slope, rsi14,
+        symbol,
+        price,
+        sma50,
+        sma200,
+        sma200Slope,
+        rsi14,
         hv60: hv ?? 0.4,
-        mdd1y, mom12m2m,
+        mdd1y,
+        mom12m2m,
         revCagr3y: q.revCagr3y,
         fcfPositive: q.fcfPositive,
         netDebtToEbitda: q.netDebtToEbitda,
@@ -46,11 +81,11 @@ export async function runEquityScreen(env: any, symbols: string[]) {
       const pass = score >= config.thresholds.passScore;
       out.push({ symbol, score, price, metrics: eq, pass });
     } catch (e) {
-      // Skip symbol on errors
       console.log(`equityScreen error for ${symbol}:`, (e as Error).message);
+      throw e;
     }
   }
   // Sort by score desc
   out.sort((a, b) => b.score - a.score);
-  return out;
+  return { results: out, diagnostics };
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,7 +4,7 @@ main = "src/index.ts"
 compatibility_date = "2025-09-07"
 
 kv_namespaces = [
-  { binding = "leapspicker", id = "00000000000000000000000000000000", preview_id = "11111111111111111111111111111111" }
+  { binding = "leapspicker", id = "41a32fe24b79414f933dfa1be849cdb0", preview_id = "11111111111111111111111111111111" }
 ]
 
 [triggers]


### PR DESCRIPTION
## Summary
- Return HTTP 500 when `ALPHA_VANTAGE_KEY` is missing instead of silently skipping all symbols
- Surface baseline filter rejections with per-symbol diagnostic logging
- Configure Cloudflare KV namespace with the production ID `41a32fe24b79414f933dfa1be849cdb0`

## Testing
- `npm test` *(fails: vitest not found; dependencies could not be installed)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68bec95aef488332b41ace6f8d070910