### PR TITLE
refactor: use CACHE KV namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { getQueryParamList } from './utils/dates';
 import { config } from './config';
 
 export interface Env {
-  leapspicker: KVNamespace;
+  CACHE: KVNamespace;
   ALPHA_VANTAGE_KEY?: string;
   FMP_KEY?: string;
   OPENAI_API_KEY?: string;

--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -6,7 +6,7 @@ export async function getDailyAdjusted(env: any, symbol: string) {
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
   const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
   const cacheKey = `av:daily:${symbol}`;
-  return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
+  return cachedGetJSON(env.CACHE, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
     const json = await res.json();

--- a/src/store/runs.ts
+++ b/src/store/runs.ts
@@ -4,10 +4,10 @@ import { getJSON, putJSON } from './kvCache';
 const LAST_RUN_KEY = 'runs:last';
 
 export async function saveRun(env: any, data: any) {
-  await putJSON(env.leapspicker, LAST_RUN_KEY, data, 7 * 24 * 60 * 60);
+  await putJSON(env.CACHE, LAST_RUN_KEY, data, 7 * 24 * 60 * 60);
 }
 
 export async function loadLastRun(env: any) {
-  const val = await getJSON(env.leapspicker, LAST_RUN_KEY);
+  const val = await getJSON(env.CACHE, LAST_RUN_KEY);
   return val ?? { ts: null, results: [] };
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,7 +4,7 @@ main = "src/index.ts"
 compatibility_date = "2025-09-07"
 
 kv_namespaces = [
-  { binding = "leapspicker", id = "00000000000000000000000000000000", preview_id = "11111111111111111111111111111111" }
+  { binding = "CACHE", id = "41a32fe24b79414f933dfa1be849cdb0", preview_id = "11111111111111111111111111111111" }
 ]
 
 [triggers]


### PR DESCRIPTION
## Summary
- use bound CACHE KV store in Alpha Vantage provider
- persist run metadata to CACHE instead of leapspicker
- rename KV binding to CACHE and update Env type
- set CACHE KV namespace ID to 41a32fe24b79414f933dfa1be849cdb0

## Testing
- `npm test`
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_b_68bed6114c6483329a6abe5b4d81964d