### PR TITLE
Fetch full Alpha Vantage history and surface API errors

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,22 +1,31 @@
-
 import { cachedGetJSON } from '../store/kvCache';
 
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
+  const params = new URLSearchParams({
+    function: 'TIME_SERIES_DAILY_ADJUSTED',
+    symbol,
+    apikey: key,
+    outputsize: 'full',
+  });
+  const url = `https://www.alphavantage.co/query?${params.toString()}`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
     const json = await res.json();
+    if (json.Note || json['Error Message']) {
+      const msg = json.Note || json['Error Message'];
+      throw new Error(`Alpha Vantage API error: ${msg}`);
+    }
     return json;
   });
 }
 
 export function extractCloses(avJson: any): number[] {
   const ts = avJson['Time Series (Daily)'];
-  if (!ts) return [];
+  if (!ts) throw new Error('Alpha Vantage response missing Time Series (Daily)');
   const rows = Object.entries(ts).map(([d, o]: any) => ({
     d,
     c: +o['5. adjusted close'],

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,7 +4,7 @@ main = "src/index.ts"
 compatibility_date = "2025-09-07"
 
 kv_namespaces = [
-  { binding = "leapspicker", id = "00000000000000000000000000000000", preview_id = "11111111111111111111111111111111" }
+  { binding = "leapspicker", id = "41a32fe24b79414f933dfa1be849cdb0", preview_id = "11111111111111111111111111111111" }
 ]
 
 [triggers]


### PR DESCRIPTION
## Summary
- request full daily history from Alpha Vantage and flag API error messages
- throw when Alpha Vantage responses omit daily series data
- ensure KV namespace points at 41a32fe24b79414f933dfa1be849cdb0

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68beda990058833287e3cb5906a0f567