### PR TITLE
Use full Alpha Vantage daily endpoint and set KV namespace

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,11 +1,10 @@
-
 import { cachedGetJSON } from '../store/kvCache';
 
-export async function getDailyAdjusted(env: any, symbol: string) {
+export async function getDaily(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
-  const cacheKey = `av:daily:${symbol}`;
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${symbol}&apikey=${key}&outputsize=full`;
+  const cacheKey = `av:daily:full:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
@@ -19,7 +18,7 @@ export function extractCloses(avJson: any): number[] {
   if (!ts) return [];
   const rows = Object.entries(ts).map(([d, o]: any) => ({
     d,
-    c: +o['5. adjusted close'],
+    c: +o['4. close'],
   }));
   rows.sort((a, b) => (a.d < b.d ? -1 : 1));
   return rows.map((r) => r.c);

--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -1,5 +1,4 @@
-
-import { getDailyAdjusted, extractCloses } from '../providers/alphaVantage';
+import { getDaily, extractCloses } from '../providers/alphaVantage';
 import { annualizedHV, maxDrawdown, momentum, rsi, sma } from '../metrics/indicators';
 import { getFundamentals, deriveQualityMetrics } from '../providers/fundamentals';
 import { scoreCandidate, EquityMetrics } from '../metrics/scoring';
@@ -9,7 +8,7 @@ export async function runEquityScreen(env: any, symbols: string[]) {
   const out: any[] = [];
   for (const symbol of symbols) {
     try {
-      const json = await getDailyAdjusted(env, symbol);
+      const json = await getDaily(env, symbol);
       const closes = extractCloses(json);
       if (closes.length < 220) continue;
       const price = closes[closes.length - 1];

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,9 @@
-
 name = "leapspicker"
 main = "src/index.ts"
 compatibility_date = "2025-09-07"
 
 kv_namespaces = [
-  { binding = "leapspicker", id = "00000000000000000000000000000000", preview_id = "11111111111111111111111111111111" }
+  { binding = "leapspicker", id = "41a32fe24b79414f933dfa1be849cdb0", preview_id = "11111111111111111111111111111111" }
 ]
 
 [triggers]


### PR DESCRIPTION
## Summary
- switch Alpha Vantage TIME_SERIES_DAILY output to full and adjust cache key
- update equity screen to call daily data function
- configure Cloudflare KV namespace to id 41a32fe24b79414f933dfa1be849cdb0

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68bee53058b08332b735144170eb72d6