### PR TITLE
Support Alpha Vantage premium history and parallel equity fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # LEAPS Screening Cloudflare Worker
 
 A Cloudflare Workers app that screens **LEAPS candidates** using equity OHLCV data (Alpha Vantage),
@@ -19,24 +18,29 @@ wrangler dev
 ```
 
 Set secrets:
+
 ```bash
 wrangler secret put ALPHA_VANTAGE_KEY
 # optional:
+wrangler secret put ALPHA_VANTAGE_PREMIUM   # set to 1 for premium accounts
 wrangler secret put FMP_KEY
 wrangler secret put OPENAI_API_KEY
 wrangler secret put OPTIONS_API_KEY
 ```
 
 ## Endpoints
+
 - `GET /` – health
 - `GET /run` – execute the full pipeline now, return JSON (pass ?symbols=AAPL,MSFT to override)
 - `GET /picks.json` – return last saved results (from KV)
 - `GET /picks` – HTML dashboard
 
 ## Configure
+
 Edit `src/config.ts` to change the universe, weights, and thresholds.
 
 ## Notes
+
 - First-time runs will cache OHLCV in KV for 24h to respect Alpha Vantage limits.
 - Indicators are computed locally to minimize API calls.
 - Options checks are stubbed with an interface; plug your provider later.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-
 import { runEquityScreen } from './screens/equityScreen';
 import { optionsFeasibility } from './screens/optionsFilter';
 import { renderHTML } from './ui/html';
@@ -11,6 +10,7 @@ import { config } from './config';
 export interface Env {
   leapspicker: KVNamespace;
   ALPHA_VANTAGE_KEY?: string;
+  ALPHA_VANTAGE_PREMIUM?: string;
   FMP_KEY?: string;
   OPENAI_API_KEY?: string;
   OPTIONS_API_KEY?: string;

--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,11 +1,12 @@
-
 import { cachedGetJSON } from '../store/kvCache';
 
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
-  const cacheKey = `av:daily:${symbol}`;
+  const premium = env.ALPHA_VANTAGE_PREMIUM === 'true' || env.ALPHA_VANTAGE_PREMIUM === '1';
+  const outputsize = premium ? 'full' : 'compact';
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=${outputsize}`;
+  const cacheKey = `av:daily:${symbol}:${outputsize}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);

--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -1,4 +1,3 @@
-
 import { getDailyAdjusted, extractCloses } from '../providers/alphaVantage';
 import { annualizedHV, maxDrawdown, momentum, rsi, sma } from '../metrics/indicators';
 import { getFundamentals, deriveQualityMetrics } from '../providers/fundamentals';
@@ -6,50 +5,62 @@ import { scoreCandidate, EquityMetrics } from '../metrics/scoring';
 import { config } from '../config';
 
 export async function runEquityScreen(env: any, symbols: string[]) {
-  const out: any[] = [];
-  for (const symbol of symbols) {
-    try {
-      const json = await getDailyAdjusted(env, symbol);
-      const closes = extractCloses(json);
-      if (closes.length < 220) continue;
-      const price = closes[closes.length - 1];
-      const sma50 = sma(closes, 50)[closes.length - 1];
-      const sma200Arr = sma(closes, 200);
-      const sma200 = sma200Arr[closes.length - 1];
-      const sma200Prev = sma200Arr[closes.length - 6]; // ~1 week slope approximation
-      const sma200Slope = sma200 - sma200Prev;
-      const rsi14 = rsi(closes, 14)[closes.length - 1];
-      const hv = annualizedHV(closes, 60)[closes.length - 1];
-      const mdd1y = maxDrawdown(closes, 252);
-      const mom12m2m = momentum(closes);
+  const results = await Promise.all(
+    symbols.map(async (symbol) => {
+      try {
+        const json = await getDailyAdjusted(env, symbol);
+        const closes = extractCloses(json);
+        if (closes.length < 252) {
+          console.log(`Skipping ${symbol}: need >=252 trading days, got ${closes.length}`);
+          return null;
+        }
+        const price = closes[closes.length - 1];
+        const sma50 = sma(closes, 50)[closes.length - 1];
+        const sma200Arr = sma(closes, 200);
+        const sma200 = sma200Arr[closes.length - 1];
+        const sma200Prev = sma200Arr[closes.length - 6]; // ~1 week slope approximation
+        const sma200Slope = sma200 - sma200Prev;
+        const rsi14 = rsi(closes, 14)[closes.length - 1];
+        const hv = annualizedHV(closes, 60)[closes.length - 1];
+        const mdd1y = maxDrawdown(closes, 252);
+        const mom12m2m = momentum(closes);
 
-      // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
+        // Baseline filters
+        if (!(price > sma200)) return null;
+        if (!(sma200Slope > 0)) return null;
+        if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) return null;
+        if (!(mdd1y >= config.thresholds.maxDrawdown)) return null;
 
-      // Fundamentals (optional)
-      const funda = await getFundamentals(env, symbol);
-      const q = deriveQualityMetrics(funda);
+        // Fundamentals (optional)
+        const funda = await getFundamentals(env, symbol);
+        const q = deriveQualityMetrics(funda);
 
-      const eq: EquityMetrics = {
-        symbol, price, sma50, sma200, sma200Slope, rsi14,
-        hv60: hv ?? 0.4,
-        mdd1y, mom12m2m,
-        revCagr3y: q.revCagr3y,
-        fcfPositive: q.fcfPositive,
-        netDebtToEbitda: q.netDebtToEbitda,
-        marginTrendOk: q.marginTrendOk,
-      };
-      const score = scoreCandidate(eq);
-      const pass = score >= config.thresholds.passScore;
-      out.push({ symbol, score, price, metrics: eq, pass });
-    } catch (e) {
-      // Skip symbol on errors
-      console.log(`equityScreen error for ${symbol}:`, (e as Error).message);
-    }
-  }
+        const eq: EquityMetrics = {
+          symbol,
+          price,
+          sma50,
+          sma200,
+          sma200Slope,
+          rsi14,
+          hv60: hv ?? 0.4,
+          mdd1y,
+          mom12m2m,
+          revCagr3y: q.revCagr3y,
+          fcfPositive: q.fcfPositive,
+          netDebtToEbitda: q.netDebtToEbitda,
+          marginTrendOk: q.marginTrendOk,
+        };
+        const score = scoreCandidate(eq);
+        const pass = score >= config.thresholds.passScore;
+        return { symbol, score, price, metrics: eq, pass };
+      } catch (e) {
+        // Skip symbol on errors
+        console.log(`equityScreen error for ${symbol}:`, (e as Error).message);
+        return null;
+      }
+    }),
+  );
+  const out = results.filter((r): r is any => r !== null);
   // Sort by score desc
   out.sort((a, b) => b.score - a.score);
   return out;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,10 @@ kv_namespaces = [
   { binding = "leapspicker", id = "41a32fe24b79414f933dfa1be849cdb0", preview_id = "11111111111111111111111111111111" }
 ]
 
+[vars]
+# set to "1" if using a premium Alpha Vantage key
+ALPHA_VANTAGE_PREMIUM = "0"
+
 [triggers]
 # After US market close (22:30 UTC is ~6:30pm ET during DST)
 crons = ["30 22 * * 1-5"]


### PR DESCRIPTION
## Summary
- detect premium Alpha Vantage usage and request full history, caching by output size
- process equity symbols in parallel with a one-year history check
- document `ALPHA_VANTAGE_PREMIUM` flag and add wrangler configuration

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68bf48a3f8148332b141f438a236f0ec