### PR TITLE
Fetch full Alpha Vantage history to produce screen results

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -4,8 +4,15 @@ import { cachedGetJSON } from '../store/kvCache';
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
-  const cacheKey = `av:daily:${symbol}`;
+  // We need at least 200+ bars for the long-term indicators (e.g. SMA200).
+  // Alpha Vantage's "compact" output only returns ~100 days which causes the
+  // equity screen to discard symbols due to insufficient history. Request the
+  // "full" dataset instead and cache it under a distinct key so previously
+  // cached compact results don't get reused.
+  const url =
+    `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}` +
+    `&apikey=${key}&outputsize=full`;
+  const cacheKey = `av:daily:${symbol}:full`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);


### PR DESCRIPTION
## Summary
- request `outputsize=full` from Alpha Vantage to obtain >200 days of price history
- cache full dataset under distinct key to avoid using earlier compact cache

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bf4d252a748332bcfade289f8f76a4