### PR TITLE
Monitor top-volume stocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 # LEAPS Screening Cloudflare Worker
 
 A Cloudflare Workers app that screens **LEAPS candidates** using equity OHLCV data (Alpha Vantage),
-optionally fundamentals (FMP), and a pluggable options provider. It computes indicators locally,
-scores candidates, and exposes JSON + HTML endpoints. It can run on a daily cron.
+optionally fundamentals (FMP), and a pluggable options provider. By default it monitors the
+top 20 highest-volume U.S. stocks via FMP, computes indicators locally, scores candidates, and
+exposes JSON + HTML endpoints. It can run on a daily cron.
 
 > For research/education only. Not investment advice.
 
@@ -34,7 +35,8 @@ wrangler secret put OPTIONS_API_KEY
 - `GET /picks` – HTML dashboard
 
 ## Configure
-Edit `src/config.ts` to change the universe, weights, and thresholds.
+Edit `src/config.ts` to change the fallback universe, number of top-volume symbols,
+weights, and thresholds.
 
 ## Notes
 - First-time runs will cache OHLCV in KV for 24h to respect Alpha Vantage limits.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 
 export const config = {
+  // Fallback symbols if top volume lookup fails
   universe: ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'META'],
+  topVolumeCount: 20,
   weights: {
     trend: 30,
     momentum: 20,

--- a/src/providers/marketData.ts
+++ b/src/providers/marketData.ts
@@ -1,0 +1,18 @@
+import { cachedGetJSON } from '../store/kvCache';
+
+export async function getTopVolumeSymbols(env: any, count = 20): Promise<string[]> {
+  if (!env.FMP_KEY) return [];
+  const key = env.FMP_KEY;
+  const url = `https://site.financialmodelingprep.com/api/v3/stock_market/actives?apikey=${key}`;
+  const cacheKey = `fmp:actives`;
+  try {
+    const data = await cachedGetJSON(env.leapspicker, cacheKey, 15 * 60, async () => {
+      const res = await fetch(url, { cf: { cacheTtl: 0 } });
+      if (!res.ok) throw new Error(`FMP actives error ${res.status}`);
+      return res.json();
+    });
+    return (data as any[]).slice(0, count).map((r) => r.symbol as string);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- fetch and cache most-active symbols from FMP
- run equity screen against top 20 high-volume stocks by default
- document new behavior and ignore node_modules

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68bf5156a7e08332aa7afc3a316e86ba