### PR TITLE
Persist runs KV without expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/store/runs.ts
+++ b/src/store/runs.ts
@@ -4,7 +4,8 @@ import { getJSON, putJSON } from './kvCache';
 const LAST_RUN_KEY = 'runs:last';
 
 export async function saveRun(env: any, data: any) {
-  await putJSON(env.leapspicker, LAST_RUN_KEY, data, 7 * 24 * 60 * 60);
+  // store the latest run indefinitely so the dashboard always has data
+  await putJSON(env.leapspicker, LAST_RUN_KEY, data);
 }
 
 export async function loadLastRun(env: any) {

--- a/test/runs.store.test.ts
+++ b/test/runs.store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { saveRun, loadLastRun } from '../src/store/runs';
+
+// simple in-memory KV stub
+function createKV() {
+  return {
+    store: {} as Record<string, string>,
+    lastOpts: undefined as any,
+    async get(key: string) {
+      return this.store[key] ? JSON.parse(this.store[key]) : null;
+    },
+    async put(key: string, value: string, opts?: any) {
+      this.store[key] = value;
+      this.lastOpts = opts;
+    },
+  };
+}
+
+describe('runs store', () => {
+  test('loadLastRun returns defaults when empty', async () => {
+    const env = { leapspicker: createKV() };
+    const data = await loadLastRun(env);
+    expect(data).toEqual({ ts: null, results: [] });
+  });
+
+  test('saveRun persists without expiration', async () => {
+    const kv = createKV();
+    const env = { leapspicker: kv };
+    const runData = { ts: 1, results: [1] };
+    await saveRun(env, runData);
+    expect(kv.lastOpts).toBeUndefined();
+    const loaded = await loadLastRun(env);
+    expect(loaded).toEqual(runData);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep last run results forever by removing the KV expiration
- Add unit test for run store defaults and persistence
- Ignore node_modules in git

## Testing
- ⚠️ `npm install` (fails: 403 Forbidden)
- ⚠️ `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_b_68bf5334854883329ce371394f3c65ff