### PR TITLE
Add run persistence test and KV binding checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { getQueryParamList } from './utils/dates';
 import { config } from './config';
 
 export interface Env {
-  leapspicker: KVNamespace;
+  leapspicker?: KVNamespace;
   ALPHA_VANTAGE_KEY?: string;
   FMP_KEY?: string;
   OPENAI_API_KEY?: string;
@@ -18,6 +18,10 @@ export interface Env {
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
+    if (!env.leapspicker) {
+      console.error('KV binding "leapspicker" is undefined');
+      return new Response('KV binding not configured', { status: 500 });
+    }
     const url = new URL(req.url);
     if (url.pathname === '/') return new Response('ok');
     if (url.pathname === '/picks.json') {
@@ -41,6 +45,10 @@ export default {
   },
 
   async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    if (!env.leapspicker) {
+      console.error('KV binding "leapspicker" is undefined');
+      return;
+    }
     const symbols = config.universe;
     const equity = await runEquityScreen(env, symbols);
     const afterOptions = await optionsFeasibility(env, equity);

--- a/src/store/runs.ts
+++ b/src/store/runs.ts
@@ -4,7 +4,13 @@ import { getJSON, putJSON } from './kvCache';
 const LAST_RUN_KEY = 'runs:last';
 
 export async function saveRun(env: any, data: any) {
-  await putJSON(env.leapspicker, LAST_RUN_KEY, data, 7 * 24 * 60 * 60);
+  try {
+    await putJSON(env.leapspicker, LAST_RUN_KEY, data, 7 * 24 * 60 * 60);
+    return true;
+  } catch (err) {
+    console.error(`Failed to save run to ${LAST_RUN_KEY}:`, err);
+    return false;
+  }
 }
 
 export async function loadLastRun(env: any) {

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { saveRun, loadLastRun } from '../src/store/runs';
+
+function mockKV() {
+  const store = new Map<string, string>();
+  return {
+    put: vi.fn(async (key: string, value: string, _opts?: any) => {
+      store.set(key, value);
+    }),
+    get: vi.fn(async (key: string, opts?: any) => {
+      const val = store.get(key);
+      if (val == null) return null;
+      return opts?.type === 'json' ? JSON.parse(val) : val;
+    }),
+  } as unknown as KVNamespace;
+}
+
+describe('run persistence', () => {
+  it('saves and loads the last run', async () => {
+    const kv = mockKV();
+    const env = { leapspicker: kv };
+    const data = { ts: 'now', results: [{ x: 1 }] };
+
+    await saveRun(env, data);
+    expect((kv.put as any).mock.calls[0][0]).toBe('runs:last');
+
+    const loaded = await loadLastRun(env);
+    expect(loaded).toEqual(data);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add vitest ensuring saveRun stores and loadLastRun retrieves last run
- log KV save errors and surface missing `leapspicker` binding on fetch/scheduled handlers

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68bf548553a483329df26dcf7bc73696