### PR TITLE
Use full Alpha Vantage data and expand default universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # LEAPS Screening Cloudflare Worker
 
 A Cloudflare Workers app that screens **LEAPS candidates** using equity OHLCV data (Alpha Vantage),
@@ -19,6 +18,7 @@ wrangler dev
 ```
 
 Set secrets:
+
 ```bash
 wrangler secret put ALPHA_VANTAGE_KEY
 # optional:
@@ -28,15 +28,18 @@ wrangler secret put OPTIONS_API_KEY
 ```
 
 ## Endpoints
+
 - `GET /` – health
-- `GET /run` – execute the full pipeline now, return JSON (pass ?symbols=AAPL,MSFT to override)
+- `GET /run` – execute the full pipeline now, return JSON (defaults to NVDA, AMD, TSLA, AAPL, MSFT, GOOG, AMZN, META, PLTR, NEE; pass ?symbols=IBM,ORCL to override)
 - `GET /picks.json` – return last saved results (from KV)
 - `GET /picks` – HTML dashboard
 
 ## Configure
+
 Edit `src/config.ts` to change the universe, weights, and thresholds.
 
 ## Notes
+
 - First-time runs will cache OHLCV in KV for 24h to respect Alpha Vantage limits.
 - Indicators are computed locally to minimize API calls.
 - Options checks are stubbed with an interface; plug your provider later.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
-
 export const config = {
-  universe: ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'META'],
+  universe: ['NVDA', 'AMD', 'TSLA', 'AAPL', 'MSFT', 'GOOG', 'AMZN', 'META', 'PLTR', 'NEE'],
   weights: {
     trend: 30,
     momentum: 20,
@@ -10,10 +9,10 @@ export const config = {
   },
   thresholds: {
     passScore: 70,
-    maxDrawdown: -0.30, // -30%
+    maxDrawdown: -0.3, // -30%
     rsiMin: 40,
     rsiMax: 65,
-    ivrMax: 0.50,
+    ivrMax: 0.5,
     minOI: 500,
     maxSpreadPct: 0.05,
     targetDeltaMin: 0.6,

--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,10 +1,9 @@
-
 import { cachedGetJSON } from '../store/kvCache';
 
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=full`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -10,7 +10,7 @@ export function renderHTML(data: any) {
       <tr>
         <td class="sym">
           <div class="symbox">
-            <div class="ticker">${escapeHTML(r.symbol ?? "—")}</div>
+            <div class="ticker">${escapeHTML(r.symbol ?? '—')}</div>
             <div class="sub">$${fmt(m.price)}</div>
           </div>
         </td>
@@ -22,12 +22,12 @@ export function renderHTML(data: any) {
         <td>${num(m.rsi14, 1)} ${badgeRSI(m.rsi14)}</td>
         <td>${pct(m.hv60)} ${badgeHV(m.hv60)}</td>
         <td>${pct(m.mdd1y)} ${badgeMDD(m.mdd1y)}</td>
-        <td>${r?.options?.ivRank ?? "—"}</td>
-        <td>${r.pass ? badge("PASS", "ok") : badge("WATCH", "warn")}</td>
-        <td class="rationale">${escapeHTML(r.rationale ?? "—")}</td>
+        <td>${r?.options?.ivRank ?? '—'}</td>
+        <td>${r.pass ? badge('PASS', 'ok') : badge('WATCH', 'warn')}</td>
+        <td class="rationale">${escapeHTML(r.rationale ?? '—')}</td>
       </tr>`;
     })
-    .join("\n");
+    .join('\n');
 
   return `<!doctype html>
 <html data-theme="light">
@@ -93,7 +93,7 @@ export function renderHTML(data: any) {
     <div class="hero">
       <div>
         <div class="title">LEAPS Candidates</div>
-        <div class="subtitle">Last run: ${data?.ts ?? "—"} • Click headers to sort • Search to filter</div>
+        <div class="subtitle">Last run: ${data?.ts ?? '—'} • Click headers to sort • Search to filter</div>
       </div>
       <div class="controls">
         <label class="pill">🔎 <input id="q" placeholder="Filter symbols & text…" /></label>
@@ -118,7 +118,7 @@ export function renderHTML(data: any) {
         </tr>
       </thead>
       <tbody>
-        ${rows || `<tr><td colspan="8" class="sub" style="padding:16px">No results yet. Hit <b>⚡ Run</b> or call <code>/run?symbols=AAPL,MSFT</code>.</td></tr>`}
+        ${rows || `<tr><td colspan="8" class="sub" style="padding:16px">No results yet. Hit <b>⚡ Run</b> or call <code>/run?symbols=NVDA,AMD,TSLA,AAPL,MSFT,GOOG,AMZN,META,PLTR,NEE</code>.</td></tr>`}
       </tbody>
     </table>
 
@@ -190,7 +190,12 @@ export function renderHTML(data: any) {
 
   // Run refresh (opens /run in a new tab to avoid blocking UI)
   refresh.addEventListener('click', () => {
-    const defaultSyms = '${(results.map(r=>r.symbol).slice(0,3).join(",") || "AAPL,MSFT,NVDA")}';
+    const defaultSyms = '${
+      results
+        .map((r) => r.symbol)
+        .slice(0, 3)
+        .join(',') || 'NVDA,AMD,TSLA,AAPL,MSFT,GOOG,AMZN,META,PLTR,NEE'
+    }';
     window.open('/run?symbols=' + encodeURIComponent(defaultSyms), '_blank');
   });
 
@@ -226,7 +231,7 @@ export function renderHTML(data: any) {
     setTimeout(()=> copycsv.textContent = '📄 CSV', 1200);
   });
   copyjson.addEventListener('click', async () => {
-    const pre = ${JSON.stringify(JSON.stringify(data ?? { ts:null, results:[] }, null, 2))};
+    const pre = ${JSON.stringify(JSON.stringify(data ?? { ts: null, results: [] }, null, 2))};
     await navigator.clipboard.writeText(pre);
     copyjson.textContent = '✅ Copied JSON';
     setTimeout(()=> copyjson.textContent = '🧾 JSON', 1200);
@@ -239,33 +244,48 @@ export function renderHTML(data: any) {
 
 /* ---------- helpers ---------- */
 
-function badge(text: string, kind: "ok" | "warn" | "bad") {
-  const cls = kind === "ok" ? "b-ok" : kind === "warn" ? "b-warn" : "b-bad";
+function badge(text: string, kind: 'ok' | 'warn' | 'bad') {
+  const cls = kind === 'ok' ? 'b-ok' : kind === 'warn' ? 'b-warn' : 'b-bad';
   return `<span class="badge ${cls}">${text}</span>`;
 }
 function badgeRSI(v?: number) {
-  if (!isFiniteNum(v)) return "";
-  if (v < 35) return badge("OVERSOLD", "warn");
-  if (v > 70) return badge("OVERBOUGHT", "warn");
-  if (v >= 40 && v <= 65) return badge("IN BAND", "ok");
-  return "";
+  if (!isFiniteNum(v)) return '';
+  if (v < 35) return badge('OVERSOLD', 'warn');
+  if (v > 70) return badge('OVERBOUGHT', 'warn');
+  if (v >= 40 && v <= 65) return badge('IN BAND', 'ok');
+  return '';
 }
 function badgeHV(v?: number) {
-  if (!isFiniteNum(v)) return "";
-  if (v < 0.25) return badge("LOW VOL", "ok");
-  if (v > 0.60) return badge("HIGH VOL", "warn");
-  return "";
+  if (!isFiniteNum(v)) return '';
+  if (v < 0.25) return badge('LOW VOL', 'ok');
+  if (v > 0.6) return badge('HIGH VOL', 'warn');
+  return '';
 }
 function badgeMDD(v?: number) {
-  if (!isFiniteNum(v)) return "";
-  if (v > -0.15) return badge("SHALLOW DD", "ok");
-  if (v < -0.40) return badge("DEEP DD", "warn");
-  return "";
+  if (!isFiniteNum(v)) return '';
+  if (v > -0.15) return badge('SHALLOW DD', 'ok');
+  if (v < -0.4) return badge('DEEP DD', 'warn');
+  return '';
 }
 
-function isFiniteNum(n: any): n is number { return typeof n === "number" && Number.isFinite(n); }
-function clamp(n: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, n)); }
-function fmt(n: number | undefined) { return isFiniteNum(n) ? n.toFixed(2) : "—"; }
-function num(n: number | undefined, d=1) { return isFiniteNum(n) ? n.toFixed(d) : "—"; }
-function pct(n: number | undefined) { return isFiniteNum(n) ? (n*100).toFixed(1) + "%" : "—"; }
-function escapeHTML(s: string) { return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!)); }
+function isFiniteNum(n: any): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+function clamp(n: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, n));
+}
+function fmt(n: number | undefined) {
+  return isFiniteNum(n) ? n.toFixed(2) : '—';
+}
+function num(n: number | undefined, d = 1) {
+  return isFiniteNum(n) ? n.toFixed(d) : '—';
+}
+function pct(n: number | undefined) {
+  return isFiniteNum(n) ? (n * 100).toFixed(1) + '%' : '—';
+}
+function escapeHTML(s: string) {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+}


### PR DESCRIPTION
## Summary
- Request full daily history from Alpha Vantage instead of compact data
- Set default equity universe to NVDA, AMD, TSLA, AAPL, MSFT, GOOG, AMZN, META, PLTR, NEE
- Update UI and docs to reflect the new default symbols

## Testing
- `npm run lint` *(fails: ESLint couldn't load configuration; uses deprecated 'root' key)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bf662e99388332b8d756316020d08a