### PR TITLE
chore: expand default tickers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,22 @@
-
 export const config = {
-  universe: ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'META'],
+  universe: [
+    'AAPL',
+    'MSFT',
+    'NVDA',
+    'GOOGL',
+    'META',
+    'CRWD',
+    'V',
+    'PYPL',
+    'UNH',
+    'AVGO',
+    'DOCU',
+    'ORCL',
+    'NVCR',
+    'ARWR',
+    'ADBE',
+    'PANW',
+  ],
   weights: {
     trend: 30,
     momentum: 20,
@@ -10,10 +26,10 @@ export const config = {
   },
   thresholds: {
     passScore: 70,
-    maxDrawdown: -0.30, // -30%
+    maxDrawdown: -0.3, // -30%
     rsiMin: 40,
     rsiMax: 65,
-    ivrMax: 0.50,
+    ivrMax: 0.5,
     minOI: 500,
     maxSpreadPct: 0.05,
     targetDeltaMin: 0.6,


### PR DESCRIPTION
## Summary
- add CRWD, V, PYPL, UNH, AVGO, DOCU, ORCL, NVCR, ARWR, ADBE, PANW to default universe

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bf6ec1811c83329118cd6df67a139e