### PR TITLE
Show all queried stocks and dim those that fail indicators

### DIFF
--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -23,28 +23,35 @@ export async function runEquityScreen(env: any, symbols: string[]) {
       const mdd1y = maxDrawdown(closes, 252);
       const mom12m2m = momentum(closes);
 
-      // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
+      // Baseline filters (record pass/fail instead of skipping)
+      const baselinePass =
+        price > sma200 &&
+        sma200Slope > 0 &&
+        rsi14 >= config.thresholds.rsiMin &&
+        rsi14 <= config.thresholds.rsiMax &&
+        mdd1y >= config.thresholds.maxDrawdown;
 
       // Fundamentals (optional)
       const funda = await getFundamentals(env, symbol);
       const q = deriveQualityMetrics(funda);
 
       const eq: EquityMetrics = {
-        symbol, price, sma50, sma200, sma200Slope, rsi14,
+        symbol,
+        price,
+        sma50,
+        sma200,
+        sma200Slope,
+        rsi14,
         hv60: hv ?? 0.4,
-        mdd1y, mom12m2m,
+        mdd1y,
+        mom12m2m,
         revCagr3y: q.revCagr3y,
         fcfPositive: q.fcfPositive,
         netDebtToEbitda: q.netDebtToEbitda,
         marginTrendOk: q.marginTrendOk,
       };
       const score = scoreCandidate(eq);
-      const pass = score >= config.thresholds.passScore;
-      out.push({ symbol, score, price, metrics: eq, pass });
+      out.push({ symbol, score, price, metrics: eq, pass: baselinePass });
     } catch (e) {
       // Skip symbol on errors
       console.log(`equityScreen error for ${symbol}:`, (e as Error).message);

--- a/src/screens/optionsFilter.ts
+++ b/src/screens/optionsFilter.ts
@@ -1,6 +1,7 @@
 
 import { basicOptionsChecks, StubOptionsProvider } from '../providers/optionsProvider';
 import { scoreCandidate } from '../metrics/scoring';
+import { config } from '../config';
 
 export async function optionsFeasibility(env: any, equityResults: any[]) {
   const provider = new StubOptionsProvider();
@@ -10,10 +11,15 @@ export async function optionsFeasibility(env: any, equityResults: any[]) {
       // In stub mode we don't actually fetch a chain; integrate real provider later.
       const checks = basicOptionsChecks([]);
       const score = scoreCandidate(r.metrics, checks);
-      out.push({ ...r, score, options: checks });
+      const pass = r.pass && score >= config.thresholds.passScore;
+      out.push({ ...r, score, options: checks, pass });
     } catch (e) {
       console.log('optionsFilter error:', (e as Error).message);
-      out.push({ ...r, options: { ivRank: undefined, oiOk: true, spreadOk: true, targetDeltaOk: true } });
+      out.push({
+        ...r,
+        options: { ivRank: undefined, oiOk: true, spreadOk: true, targetDeltaOk: true },
+        pass: false,
+      });
     }
   }
   out.sort((a, b) => b.score - a.score);

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -7,7 +7,7 @@ export function renderHTML(data: any) {
       const score = Number.isFinite(r.score) ? r.score : 0;
 
       return `
-      <tr>
+      <tr class="${r.pass ? '' : 'dim'}">
         <td class="sym">
           <div class="symbox">
             <div class="ticker">${escapeHTML(r.symbol ?? "—")}</div>
@@ -86,6 +86,7 @@ export function renderHTML(data: any) {
     .rationale{max-width:520px}
     .footer{margin:16px 0;color:var(--muted);font-size:12px}
     .hidden{display:none}
+    .dim{opacity:.45}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- retain all queried symbols in equity screen and mark baseline pass without filtering
- recompute recommendation pass after options checks
- dim non-recommended rows on picks HTML page

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*


------
https://chatgpt.com/codex/tasks/task_b_68bf77ea948c8332a9aaa458cb917f8d