### PR TITLE
Include failed symbols in screen results

### DIFF
--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -1,4 +1,3 @@
-
 import { getDailyAdjusted, extractCloses } from '../providers/alphaVantage';
 import { annualizedHV, maxDrawdown, momentum, rsi, sma } from '../metrics/indicators';
 import { getFundamentals, deriveQualityMetrics } from '../providers/fundamentals';
@@ -23,27 +22,41 @@ export async function runEquityScreen(env: any, symbols: string[]) {
       const mdd1y = maxDrawdown(closes, 252);
       const mom12m2m = momentum(closes);
 
-      // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
-
-      // Fundamentals (optional)
-      const funda = await getFundamentals(env, symbol);
-      const q = deriveQualityMetrics(funda);
-
-      const eq: EquityMetrics = {
-        symbol, price, sma50, sma200, sma200Slope, rsi14,
-        hv60: hv ?? 0.4,
-        mdd1y, mom12m2m,
-        revCagr3y: q.revCagr3y,
-        fcfPositive: q.fcfPositive,
-        netDebtToEbitda: q.netDebtToEbitda,
-        marginTrendOk: q.marginTrendOk,
+      const gates = {
+        aboveSma200: price > sma200,
+        slopeUp: sma200Slope > 0,
+        rsiOk: rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax,
+        drawdownOk: mdd1y >= config.thresholds.maxDrawdown,
       };
+      const baselinePass = Object.values(gates).every(Boolean);
+
+      const baseEq: EquityMetrics = {
+        symbol,
+        price,
+        sma50,
+        sma200,
+        sma200Slope,
+        rsi14,
+        hv60: hv ?? 0.4,
+        mdd1y,
+        mom12m2m,
+      };
+
+      let eq = baseEq;
+      if (baselinePass) {
+        const funda = await getFundamentals(env, symbol);
+        const q = deriveQualityMetrics(funda);
+        eq = {
+          ...baseEq,
+          revCagr3y: q.revCagr3y,
+          fcfPositive: q.fcfPositive,
+          netDebtToEbitda: q.netDebtToEbitda,
+          marginTrendOk: q.marginTrendOk,
+        };
+      }
+
       const score = scoreCandidate(eq);
-      const pass = score >= config.thresholds.passScore;
+      const pass = baselinePass && score >= config.thresholds.passScore;
       out.push({ symbol, score, price, metrics: eq, pass });
     } catch (e) {
       // Skip symbol on errors

--- a/test/equityScreen.test.ts
+++ b/test/equityScreen.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/providers/alphaVantage', () => ({
+  getDailyAdjusted: vi.fn((_env, symbol: string) => symbol),
+  extractCloses: (symbol: string) => {
+    if (symbol === 'GOOD') return Array.from({ length: 220 }, (_, i) => i + 1);
+    return Array(220).fill(50);
+  },
+}));
+
+vi.mock('../src/metrics/indicators', () => ({
+  sma: (closes: number[], _n: number) => closes.map((_, i) => i),
+  rsi: () => Array(220).fill(50),
+  annualizedHV: () => Array(220).fill(0.2),
+  maxDrawdown: () => -0.1,
+  momentum: () => 0.1,
+}));
+
+vi.mock('../src/providers/fundamentals', () => ({
+  getFundamentals: vi.fn(),
+  deriveQualityMetrics: () => ({
+    revCagr3y: 0.1,
+    fcfPositive: true,
+    netDebtToEbitda: 1,
+    marginTrendOk: true,
+  }),
+}));
+
+vi.mock('../src/metrics/scoring', () => ({
+  scoreCandidate: (eq: any) => (eq.symbol === 'GOOD' ? 80 : 10),
+}));
+
+describe('runEquityScreen', () => {
+  it('returns all symbols with pass flag', async () => {
+    const { runEquityScreen } = await import('../src/screens/equityScreen');
+    const res = await runEquityScreen({}, ['GOOD', 'BAD']);
+    expect(res).toHaveLength(2);
+    const good = res.find((r) => r.symbol === 'GOOD');
+    const bad = res.find((r) => r.symbol === 'BAD');
+    expect(good?.pass).toBe(true);
+    expect(bad?.pass).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Retain all equities in screening output and tag baseline gate failures so the UI can show greyed-out entries.
- Add regression test ensuring both passing and failing symbols appear in results with correct `pass` flags.

## Testing
- `npm test` (pass)
- `npm run lint` (fails: ESLint couldn't find eslint.config.js)


------
https://chatgpt.com/codex/tasks/task_b_68bf7b1dd1c08332997432ffc263ff1c