### PR TITLE
Fix Run button to use configured universe

### DIFF
--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -1,5 +1,13 @@
+import { config } from '../config';
+
 export function renderHTML(data: any) {
   const results = (data?.results ?? []) as any[];
+
+  const defaultSymsList =
+    Array.isArray(config.universe) && config.universe.length
+      ? config.universe
+      : results.map((r) => r.symbol).slice(0, 3);
+  const defaultSyms = defaultSymsList.filter(Boolean).join(',') || 'AAPL,MSFT,NVDA';
 
   const rows = results
     .map((r) => {
@@ -10,7 +18,7 @@ export function renderHTML(data: any) {
       <tr>
         <td class="sym">
           <div class="symbox">
-            <div class="ticker">${escapeHTML(r.symbol ?? "—")}</div>
+            <div class="ticker">${escapeHTML(r.symbol ?? '—')}</div>
             <div class="sub">$${fmt(m.price)}</div>
           </div>
         </td>
@@ -22,12 +30,12 @@ export function renderHTML(data: any) {
         <td>${num(m.rsi14, 1)} ${badgeRSI(m.rsi14)}</td>
         <td>${pct(m.hv60)} ${badgeHV(m.hv60)}</td>
         <td>${pct(m.mdd1y)} ${badgeMDD(m.mdd1y)}</td>
-        <td>${r?.options?.ivRank ?? "—"}</td>
-        <td>${r.pass ? badge("PASS", "ok") : badge("WATCH", "warn")}</td>
-        <td class="rationale">${escapeHTML(r.rationale ?? "—")}</td>
+        <td>${r?.options?.ivRank ?? '—'}</td>
+        <td>${r.pass ? badge('PASS', 'ok') : badge('WATCH', 'warn')}</td>
+        <td class="rationale">${escapeHTML(r.rationale ?? '—')}</td>
       </tr>`;
     })
-    .join("\n");
+    .join('\n');
 
   return `<!doctype html>
 <html data-theme="light">
@@ -93,7 +101,7 @@ export function renderHTML(data: any) {
     <div class="hero">
       <div>
         <div class="title">LEAPS Candidates</div>
-        <div class="subtitle">Last run: ${data?.ts ?? "—"} • Click headers to sort • Search to filter</div>
+        <div class="subtitle">Last run: ${data?.ts ?? '—'} • Click headers to sort • Search to filter</div>
       </div>
       <div class="controls">
         <label class="pill">🔎 <input id="q" placeholder="Filter symbols & text…" /></label>
@@ -190,7 +198,7 @@ export function renderHTML(data: any) {
 
   // Run refresh (opens /run in a new tab to avoid blocking UI)
   refresh.addEventListener('click', () => {
-    const defaultSyms = '${(results.map(r=>r.symbol).slice(0,3).join(",") || "AAPL,MSFT,NVDA")}';
+    const defaultSyms = '${defaultSyms}';
     window.open('/run?symbols=' + encodeURIComponent(defaultSyms), '_blank');
   });
 
@@ -226,7 +234,7 @@ export function renderHTML(data: any) {
     setTimeout(()=> copycsv.textContent = '📄 CSV', 1200);
   });
   copyjson.addEventListener('click', async () => {
-    const pre = ${JSON.stringify(JSON.stringify(data ?? { ts:null, results:[] }, null, 2))};
+    const pre = ${JSON.stringify(JSON.stringify(data ?? { ts: null, results: [] }, null, 2))};
     await navigator.clipboard.writeText(pre);
     copyjson.textContent = '✅ Copied JSON';
     setTimeout(()=> copyjson.textContent = '🧾 JSON', 1200);
@@ -239,33 +247,48 @@ export function renderHTML(data: any) {
 
 /* ---------- helpers ---------- */
 
-function badge(text: string, kind: "ok" | "warn" | "bad") {
-  const cls = kind === "ok" ? "b-ok" : kind === "warn" ? "b-warn" : "b-bad";
+function badge(text: string, kind: 'ok' | 'warn' | 'bad') {
+  const cls = kind === 'ok' ? 'b-ok' : kind === 'warn' ? 'b-warn' : 'b-bad';
   return `<span class="badge ${cls}">${text}</span>`;
 }
 function badgeRSI(v?: number) {
-  if (!isFiniteNum(v)) return "";
-  if (v < 35) return badge("OVERSOLD", "warn");
-  if (v > 70) return badge("OVERBOUGHT", "warn");
-  if (v >= 40 && v <= 65) return badge("IN BAND", "ok");
-  return "";
+  if (!isFiniteNum(v)) return '';
+  if (v < 35) return badge('OVERSOLD', 'warn');
+  if (v > 70) return badge('OVERBOUGHT', 'warn');
+  if (v >= 40 && v <= 65) return badge('IN BAND', 'ok');
+  return '';
 }
 function badgeHV(v?: number) {
-  if (!isFiniteNum(v)) return "";
-  if (v < 0.25) return badge("LOW VOL", "ok");
-  if (v > 0.60) return badge("HIGH VOL", "warn");
-  return "";
+  if (!isFiniteNum(v)) return '';
+  if (v < 0.25) return badge('LOW VOL', 'ok');
+  if (v > 0.6) return badge('HIGH VOL', 'warn');
+  return '';
 }
 function badgeMDD(v?: number) {
-  if (!isFiniteNum(v)) return "";
-  if (v > -0.15) return badge("SHALLOW DD", "ok");
-  if (v < -0.40) return badge("DEEP DD", "warn");
-  return "";
+  if (!isFiniteNum(v)) return '';
+  if (v > -0.15) return badge('SHALLOW DD', 'ok');
+  if (v < -0.4) return badge('DEEP DD', 'warn');
+  return '';
 }
 
-function isFiniteNum(n: any): n is number { return typeof n === "number" && Number.isFinite(n); }
-function clamp(n: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, n)); }
-function fmt(n: number | undefined) { return isFiniteNum(n) ? n.toFixed(2) : "—"; }
-function num(n: number | undefined, d=1) { return isFiniteNum(n) ? n.toFixed(d) : "—"; }
-function pct(n: number | undefined) { return isFiniteNum(n) ? (n*100).toFixed(1) + "%" : "—"; }
-function escapeHTML(s: string) { return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!)); }
+function isFiniteNum(n: any): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+function clamp(n: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, n));
+}
+function fmt(n: number | undefined) {
+  return isFiniteNum(n) ? n.toFixed(2) : '—';
+}
+function num(n: number | undefined, d = 1) {
+  return isFiniteNum(n) ? n.toFixed(d) : '—';
+}
+function pct(n: number | undefined) {
+  return isFiniteNum(n) ? (n * 100).toFixed(1) + '%' : '—';
+}
+function escapeHTML(s: string) {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+}


### PR DESCRIPTION
## Summary
- use configured universe to build Run button symbol list
- fall back to existing results or default tickers if universe undefined

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*


------
https://chatgpt.com/codex/tasks/task_b_68bf7ff63a4c8332a2ba5201a4596ff9