### PR TITLE
Run button uses full universe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ export default {
       return new Response(renderHTML(last), { headers: { 'content-type': 'text/html' } });
     }
     if (url.pathname === '/run') {
-      const symbols = getQueryParamList(url, 'symbols') ?? config.universe;
+      const explicit = getQueryParamList(url, 'symbols') ?? [];
+      const symbols = explicit.length ? explicit : config.universe; // no rotation
       const equity = await runEquityScreen(env, symbols);
       const afterOptions = await optionsFeasibility(env, equity);
       const withExplainers = await explainWithGPT(env, afterOptions);

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -190,8 +190,7 @@ export function renderHTML(data: any) {
 
   // Run refresh (opens /run in a new tab to avoid blocking UI)
   refresh.addEventListener('click', () => {
-    const defaultSyms = '${(results.map(r=>r.symbol).slice(0,3).join(",") || "AAPL,MSFT,NVDA")}';
-    window.open('/run?symbols=' + encodeURIComponent(defaultSyms), '_blank');
+    window.open('/run', '_blank');
   });
 
   // Copy CSV / JSON


### PR DESCRIPTION
## Summary
- ensure /run endpoint uses full config universe when no symbols provided
- update UI Run button to call /run without rotating symbols

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68bff7a90be083329d01fdffef10262e