### PR TITLE
feat: show run symbols

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,22 @@ export default {
     }
     if (url.pathname === '/run') {
       const symbols = getQueryParamList(url, 'symbols') ?? config.universe;
+      const fullUniverse =
+        symbols.length === config.universe.length &&
+        symbols.every((s) => config.universe.includes(s));
       const equity = await runEquityScreen(env, symbols);
       const afterOptions = await optionsFeasibility(env, equity);
       const withExplainers = await explainWithGPT(env, afterOptions);
-      const stamped = { ts: new Date().toISOString(), results: withExplainers };
+      const stamped = {
+        ts: new Date().toISOString(),
+        symbols,
+        fullUniverse,
+        results: withExplainers,
+      };
       await saveRun(env, stamped);
-      return new Response(renderJSON(stamped), { headers: { 'content-type': 'application/json' } });
+      return new Response(renderJSON(stamped), {
+        headers: { 'content-type': 'application/json' },
+      });
     }
     return new Response('Not found', { status: 404 });
   },
@@ -45,7 +55,12 @@ export default {
     const equity = await runEquityScreen(env, symbols);
     const afterOptions = await optionsFeasibility(env, equity);
     const withExplainers = await explainWithGPT(env, afterOptions);
-    const stamped = { ts: new Date().toISOString(), results: withExplainers };
+    const stamped = {
+      ts: new Date().toISOString(),
+      symbols,
+      fullUniverse: true,
+      results: withExplainers,
+    };
     await saveRun(env, stamped);
   },
 };

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -1,5 +1,7 @@
 export function renderHTML(data: any) {
   const results = (data?.results ?? []) as any[];
+  const symbols = (data?.symbols ?? []) as string[];
+  const fullUniverse = Boolean(data?.fullUniverse);
 
   const rows = results
     .map((r) => {
@@ -124,6 +126,8 @@ export function renderHTML(data: any) {
 
     <div class="meta">
       <span>Rows: <b id="rc">${results.length}</b></span>
+      <span>Symbols: <b>${symbols.join(', ') || '—'}</b></span>
+      <span>Universe: <b>${fullUniverse ? 'full' : 'partial'}</b></span>
       <span>Theme: <b id="th">light</b></span>
     </div>
     <div class="footer">Pro tip: tweak your universe and thresholds in <code>src/config.ts</code>.</div>
@@ -190,8 +194,7 @@ export function renderHTML(data: any) {
 
   // Run refresh (opens /run in a new tab to avoid blocking UI)
   refresh.addEventListener('click', () => {
-    const defaultSyms = '${(results.map(r=>r.symbol).slice(0,3).join(",") || "AAPL,MSFT,NVDA")}';
-    window.open('/run?symbols=' + encodeURIComponent(defaultSyms), '_blank');
+    window.open('/run', '_blank');
   });
 
   // Copy CSV / JSON


### PR DESCRIPTION
## Summary
- verify `/run` executes the complete stock universe and record symbols
- display tickers and universe status in the UI meta section
- run button now triggers a full-universe refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bffb72f1a88332bc6a11f8caebc43d