### PR TITLE
Run button triggers full universe run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ wrangler secret put OPTIONS_API_KEY
 
 ## Endpoints
 - `GET /` – health
-- `GET /run` – execute the full pipeline now, return JSON (pass ?symbols=AAPL,MSFT to override)
+- `GET /run?all=1` – execute the full pipeline for the configured universe (pass ?symbols=AAPL,MSFT to override)
 - `GET /picks.json` – return last saved results (from KV)
 - `GET /picks` – HTML dashboard
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ export default {
       return new Response(renderHTML(last), { headers: { 'content-type': 'text/html' } });
     }
     if (url.pathname === '/run') {
-      const symbols = getQueryParamList(url, 'symbols') ?? config.universe;
+      const symbols =
+        url.searchParams.get('all') === '1'
+          ? config.universe
+          : getQueryParamList(url, 'symbols') ?? config.universe;
       const equity = await runEquityScreen(env, symbols);
       const afterOptions = await optionsFeasibility(env, equity);
       const withExplainers = await explainWithGPT(env, afterOptions);

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -118,7 +118,7 @@ export function renderHTML(data: any) {
         </tr>
       </thead>
       <tbody>
-        ${rows || `<tr><td colspan="8" class="sub" style="padding:16px">No results yet. Hit <b>⚡ Run</b> or call <code>/run?symbols=AAPL,MSFT</code>.</td></tr>`}
+        ${rows || `<tr><td colspan="8" class="sub" style="padding:16px">No results yet. Hit <b>⚡ Run</b> or call <code>/run?all=1</code>.</td></tr>`}
       </tbody>
     </table>
 
@@ -190,8 +190,7 @@ export function renderHTML(data: any) {
 
   // Run refresh (opens /run in a new tab to avoid blocking UI)
   refresh.addEventListener('click', () => {
-    const defaultSyms = '${(results.map(r=>r.symbol).slice(0,3).join(",") || "AAPL,MSFT,NVDA")}';
-    window.open('/run?symbols=' + encodeURIComponent(defaultSyms), '_blank');
+    window.open('/run?all=1', '_blank');
   });
 
   // Copy CSV / JSON


### PR DESCRIPTION
## Summary
- Run button now opens `/run?all=1` to process the entire configured universe
- Server interprets `?all=1` by running `config.universe`
- Document `/run?all=1` in README
- Ignore `node_modules` in version control

## Testing
- `npm test` *(fails: vitest not found after dependency install error)*


------
https://chatgpt.com/codex/tasks/task_b_68c01348708c8332b11763ad1ede148b