### PR TITLE
Emit all equity screen rows with pass flags

### DIFF
--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -1,4 +1,3 @@
-
 import { getDailyAdjusted, extractCloses } from '../providers/alphaVantage';
 import { annualizedHV, maxDrawdown, momentum, rsi, sma } from '../metrics/indicators';
 import { getFundamentals, deriveQualityMetrics } from '../providers/fundamentals';
@@ -11,43 +10,56 @@ export async function runEquityScreen(env: any, symbols: string[]) {
     try {
       const json = await getDailyAdjusted(env, symbol);
       const closes = extractCloses(json);
-      if (closes.length < 220) continue;
-      const price = closes[closes.length - 1];
-      const sma50 = sma(closes, 50)[closes.length - 1];
-      const sma200Arr = sma(closes, 200);
-      const sma200 = sma200Arr[closes.length - 1];
-      const sma200Prev = sma200Arr[closes.length - 6]; // ~1 week slope approximation
-      const sma200Slope = sma200 - sma200Prev;
-      const rsi14 = rsi(closes, 14)[closes.length - 1];
-      const hv = annualizedHV(closes, 60)[closes.length - 1];
-      const mdd1y = maxDrawdown(closes, 252);
-      const mom12m2m = momentum(closes);
+      if (closes.length < 220) {
+        out.push({ symbol, score: 0, pass: false, gates: { enoughHistory: false } });
+      } else {
+        const price = closes[closes.length - 1];
+        const sma50 = sma(closes, 50)[closes.length - 1];
+        const sma200Arr = sma(closes, 200);
+        const sma200 = sma200Arr[closes.length - 1];
+        const sma200Prev = sma200Arr[closes.length - 6]; // ~1 week slope approximation
+        const sma200Slope = sma200 - sma200Prev;
+        const rsi14 = rsi(closes, 14)[closes.length - 1];
+        const hv = annualizedHV(closes, 60)[closes.length - 1];
+        const mdd1y = maxDrawdown(closes, 252);
+        const mom12m2m = momentum(closes);
 
-      // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
+        // Baseline gates
+        const gates = {
+          enoughHistory: true,
+          priceAboveSma200: price > sma200,
+          sma200SlopePositive: sma200Slope > 0,
+          rsiInRange: rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax,
+          maxDrawdownOk: mdd1y >= config.thresholds.maxDrawdown,
+        };
+        const pass = Object.values(gates).every(Boolean);
 
-      // Fundamentals (optional)
-      const funda = await getFundamentals(env, symbol);
-      const q = deriveQualityMetrics(funda);
+        // Fundamentals (optional)
+        const funda = await getFundamentals(env, symbol);
+        const q = deriveQualityMetrics(funda);
 
-      const eq: EquityMetrics = {
-        symbol, price, sma50, sma200, sma200Slope, rsi14,
-        hv60: hv ?? 0.4,
-        mdd1y, mom12m2m,
-        revCagr3y: q.revCagr3y,
-        fcfPositive: q.fcfPositive,
-        netDebtToEbitda: q.netDebtToEbitda,
-        marginTrendOk: q.marginTrendOk,
-      };
-      const score = scoreCandidate(eq);
-      const pass = score >= config.thresholds.passScore;
-      out.push({ symbol, score, price, metrics: eq, pass });
+        const eq: EquityMetrics = {
+          symbol,
+          price,
+          sma50,
+          sma200,
+          sma200Slope,
+          rsi14,
+          hv60: hv ?? 0.4,
+          mdd1y,
+          mom12m2m,
+          revCagr3y: q.revCagr3y,
+          fcfPositive: q.fcfPositive,
+          netDebtToEbitda: q.netDebtToEbitda,
+          marginTrendOk: q.marginTrendOk,
+        };
+        const score = scoreCandidate(eq);
+        out.push({ symbol, score, price, metrics: eq, pass, gates });
+      }
     } catch (e) {
-      // Skip symbol on errors
+      // Emit row on errors
       console.log(`equityScreen error for ${symbol}:`, (e as Error).message);
+      out.push({ symbol, score: 0, pass: false, gates: { error: true } });
     }
   }
   // Sort by score desc


### PR DESCRIPTION
## Summary
- Emit every screened symbol with pass status, gate results, and score
- Handle insufficient data or errors by outputting failed rows instead of skipping

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68c095c563288332925cbde9461eae15