### PR TITLE
Fetch full Alpha Vantage data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,10 +1,9 @@
-
 import { cachedGetJSON } from '../store/kvCache';
 
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=full`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });


### PR DESCRIPTION
## Summary
- query Alpha Vantage with `outputsize=full` to provide data beyond the 200-day filter
- ignore `node_modules` in version control

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c164d80b1c833285eb03c7ff3c2c51