### PR TITLE
Show full AlphaVantage data and keep all screen results

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -4,7 +4,7 @@ import { cachedGetJSON } from '../store/kvCache';
 export async function getDailyAdjusted(env: any, symbol: string) {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
-  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=full`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });

--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -23,11 +23,13 @@ export async function runEquityScreen(env: any, symbols: string[]) {
       const mdd1y = maxDrawdown(closes, 252);
       const mom12m2m = momentum(closes);
 
-      // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
+      // Baseline checks
+      const baselinePass =
+        price > sma200 &&
+        sma200Slope > 0 &&
+        rsi14 >= config.thresholds.rsiMin &&
+        rsi14 <= config.thresholds.rsiMax &&
+        mdd1y >= config.thresholds.maxDrawdown;
 
       // Fundamentals (optional)
       const funda = await getFundamentals(env, symbol);
@@ -43,7 +45,7 @@ export async function runEquityScreen(env: any, symbols: string[]) {
         marginTrendOk: q.marginTrendOk,
       };
       const score = scoreCandidate(eq);
-      const pass = score >= config.thresholds.passScore;
+      const pass = baselinePass && score >= config.thresholds.passScore;
       out.push({ symbol, score, price, metrics: eq, pass });
     } catch (e) {
       // Skip symbol on errors


### PR DESCRIPTION
## Summary
- Request Alpha Vantage daily adjusted data with `outputsize=full` for complete history
- Preserve all screened equities by computing baseline pass flags instead of skipping early

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68c16dda49248332b47a9b611f768b6d