### PR TITLE
Expose all equity results

### DIFF
--- a/src/screens/equityScreen.ts
+++ b/src/screens/equityScreen.ts
@@ -23,12 +23,8 @@ export async function runEquityScreen(env: any, symbols: string[]) {
       const mdd1y = maxDrawdown(closes, 252);
       const mom12m2m = momentum(closes);
 
-      // Baseline filters
-      if (!(price > sma200)) continue;
-      if (!(sma200Slope > 0)) continue;
-      if (!(rsi14 >= config.thresholds.rsiMin && rsi14 <= config.thresholds.rsiMax)) continue;
-      if (!(mdd1y >= config.thresholds.maxDrawdown)) continue;
-
+      // Evaluate every symbol; technical thresholds are reflected in the score
+      // rather than acting as hard filters so all data reaches the UI.
       // Fundamentals (optional)
       const funda = await getFundamentals(env, symbol);
       const q = deriveQualityMetrics(funda);


### PR DESCRIPTION
## Summary
- Remove baseline gating from equity screen to surface every symbol's metrics
- Document that technical thresholds now influence score rather than filtering results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c19efa3ea483328f9c1c7434a063d6