### PR TITLE
Handle Alpha Vantage soft errors gracefully

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,16 +1,26 @@
 
 import { cachedGetJSON } from '../store/kvCache';
 
-export async function getDailyAdjusted(env: any, symbol: string) {
+export type AlphaVantageResult<T = any> =
+  | { type: 'success'; data: T }
+  | { type: 'error'; message: string };
+
+export async function getDailyAdjusted(env: any, symbol: string): Promise<AlphaVantageResult> {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
   const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=compact`;
   const cacheKey = `av:daily:${symbol}`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
-    if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
-    const json = await res.json();
-    return json;
+    if (!res.ok) {
+      return { type: 'error', message: `Alpha Vantage error ${res.status}` };
+    }
+    const json: any = await res.json();
+    const softError = json['Error Message'] || json['Information'] || json['Note'];
+    if (softError) {
+      return { type: 'error', message: softError };
+    }
+    return { type: 'success', data: json };
   });
 }
 

--- a/src/providers/openaiExplain.ts
+++ b/src/providers/openaiExplain.ts
@@ -6,25 +6,34 @@
 
 type Result = {
   symbol: string;
-  score: number;
-  price: number;
-  metrics: any;
+  score?: number;
+  price?: number;
+  metrics?: any;
   options?: any;
   rationale?: string;
+  error?: string;
 };
 
 export async function explainWithGPT(env: any, results: Result[]): Promise<Result[]> {
   if (!env.OPENAI_API_KEY) {
-    return results.map((r) => ({
-      ...r,
-      rationale:
-        `Trend above long-term average with supportive momentum. ` +
-        `Volatility and drawdown appear manageable. Options liquidity assumed OK (stub). ` +
-        `Caution: verify IV rank and spreads before selecting LEAPS.`,
-    }));
+    return results.map((r) =>
+      r.error
+        ? r
+        : {
+            ...r,
+            rationale:
+              `Trend above long-term average with supportive momentum. ` +
+              `Volatility and drawdown appear manageable. Options liquidity assumed OK (stub). ` +
+              `Caution: verify IV rank and spreads before selecting LEAPS.`,
+          },
+    );
   }
   const explained: Result[] = [];
   for (const r of results) {
+    if (r.error) {
+      explained.push(r);
+      continue;
+    }
     try {
       const sys =
         "You are a buy-side analyst. Write a ~120-word, risk-aware rationale for a LEAPS entry. " +

--- a/src/screens/optionsFilter.ts
+++ b/src/screens/optionsFilter.ts
@@ -6,6 +6,10 @@ export async function optionsFeasibility(env: any, equityResults: any[]) {
   const provider = new StubOptionsProvider();
   const out: any[] = [];
   for (const r of equityResults) {
+    if (r.error) {
+      out.push(r);
+      continue;
+    }
     try {
       // In stub mode we don't actually fetch a chain; integrate real provider later.
       const checks = basicOptionsChecks([]);
@@ -16,6 +20,6 @@ export async function optionsFeasibility(env: any, equityResults: any[]) {
       out.push({ ...r, options: { ivRank: undefined, oiOk: true, spreadOk: true, targetDeltaOk: true } });
     }
   }
-  out.sort((a, b) => b.score - a.score);
+  out.sort((a, b) => (b.score ?? -Infinity) - (a.score ?? -Infinity));
   return out;
 }

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -3,6 +3,17 @@ export function renderHTML(data: any) {
 
   const rows = results
     .map((r) => {
+      if (r.error) {
+        return `
+      <tr>
+        <td class="sym">
+          <div class="symbox">
+            <div class="ticker">${escapeHTML(r.symbol ?? "—")}</div>
+          </div>
+        </td>
+        <td colspan="7" class="rationale">${escapeHTML(r.error)}</td>
+      </tr>`;
+      }
       const m = r.metrics ?? {};
       const score = Number.isFinite(r.score) ? r.score : 0;
 


### PR DESCRIPTION
## Summary
- Detect Alpha Vantage informational/Note/Error payloads and normalize responses into a discriminated union
- Propagate soft errors through screening, options checks, and GPT explanations while keeping them in results
- Render API errors clearly in the HTML table output

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68c1b82652448332b09e3d82f4765779