### PR TITLE
Version Alpha Vantage cache for full history

### DIFF
--- a/src/providers/alphaVantage.ts
+++ b/src/providers/alphaVantage.ts
@@ -1,16 +1,29 @@
 import { cachedGetJSON } from '../store/kvCache';
 
-export async function getDailyAdjusted(env: any, symbol: string) {
+type AlphaVantageError = {
+  Note?: string;
+  Information?: string;
+  'Error Message'?: string;
+};
+
+type AlphaVantageDaily = {
+  'Time Series (Daily)': Record<string, { '5. adjusted close': string }>;
+};
+
+export async function getDailyAdjusted(env: any, symbol: string): Promise<AlphaVantageDaily> {
   const key = env.ALPHA_VANTAGE_KEY;
   if (!key) throw new Error('ALPHA_VANTAGE_KEY not set');
   const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${symbol}&apikey=${key}&outputsize=full`;
-  const cacheKey = `av:daily:${symbol}`;
+  const cacheKey = `av:daily:${symbol}:full`;
   return cachedGetJSON(env.leapspicker, cacheKey, 24 * 60 * 60, async () => {
     const res = await fetch(url, { cf: { cacheTtl: 0 } });
     if (!res.ok) throw new Error(`Alpha Vantage error ${res.status}`);
-    const json = await res.json();
-    const ts = json['Time Series (Daily)'];
-    const errMsg = json['Note'] ?? json['Information'] ?? json['Error Message'];
+    const json: AlphaVantageDaily | AlphaVantageError = await res.json();
+    const ts = (json as AlphaVantageDaily)['Time Series (Daily)'];
+    const errMsg =
+      (json as AlphaVantageError).Note ??
+      (json as AlphaVantageError).Information ??
+      (json as AlphaVantageError)['Error Message'];
     if (!ts || errMsg) {
       throw new Error(errMsg || 'Alpha Vantage response missing Time Series (Daily)');
     }
@@ -18,7 +31,7 @@ export async function getDailyAdjusted(env: any, symbol: string) {
   });
 }
 
-export function extractCloses(avJson: any): number[] {
+export function extractCloses(avJson: AlphaVantageDaily): number[] {
   if (!avJson || typeof avJson !== 'object') {
     throw new Error('Alpha Vantage data is undefined or invalid');
   }
@@ -26,7 +39,7 @@ export function extractCloses(avJson: any): number[] {
   if (!ts) {
     throw new Error('Alpha Vantage data missing Time Series (Daily)');
   }
-  const rows = Object.entries(ts).map(([d, o]: any) => ({
+  const rows = Object.entries(ts).map(([d, o]) => ({
     d,
     c: +o['5. adjusted close'],
   }));


### PR DESCRIPTION
## Summary
- Support Alpha Vantage `outputsize=full` when requesting daily-adjusted data
- Version cached daily data using an `:full` suffix
- Retain union-based soft error detection when validating responses

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68c1de46f8e88332997ad50977732ca4