### PR TITLE
feat: handle openai rate limits and cache rationales

### DIFF
--- a/src/providers/openaiExplain.ts
+++ b/src/providers/openaiExplain.ts
@@ -13,6 +13,54 @@ type Result = {
   rationale?: string;
 };
 
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function metricsHash(metrics: any): Promise<string> {
+  const json = JSON.stringify(metrics);
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(json),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function callGPTWithRetry(env: any, body: any, maxAttempts = 5) {
+  let backoff = 1000;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 429) {
+      let wait = backoff;
+      const retryAfter = res.headers.get('Retry-After');
+      if (retryAfter) {
+        const parsed = parseInt(retryAfter, 10);
+        if (!isNaN(parsed)) wait = Math.max(wait, parsed * 1000);
+      }
+      const reset = res.headers.get('x-ratelimit-reset-requests');
+      if (reset) {
+        const resetMs = parseFloat(reset) * 1000 - Date.now();
+        if (!isNaN(resetMs)) wait = Math.max(wait, resetMs);
+      }
+      await sleep(wait);
+      backoff *= 2;
+      continue;
+    }
+    if (!res.ok) throw new Error(`OpenAI error ${res.status}`);
+    return res.json();
+  }
+  throw new Error('OpenAI rate limit exceeded');
+}
+
 export async function explainWithGPT(env: any, results: Result[]): Promise<Result[]> {
   if (!env.OPENAI_API_KEY) {
     return results.map((r) => ({
@@ -23,46 +71,55 @@ export async function explainWithGPT(env: any, results: Result[]): Promise<Resul
         `Caution: verify IV rank and spreads before selecting LEAPS.`,
     }));
   }
+  const limit = env.EXPLAIN_TOP_N ? parseInt(env.EXPLAIN_TOP_N, 10) : 10;
   const explained: Result[] = [];
-  for (const r of results) {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (i >= limit) {
+      explained.push(r);
+      continue;
+    }
     try {
+      const hash = await metricsHash(r.metrics);
+      const cacheKey = `rationale:${r.symbol}:${hash}`;
+      const cached = await env.leapspicker.get(cacheKey);
+      if (cached) {
+        explained.push({ ...r, rationale: cached });
+        continue;
+      }
       const sys =
-        "You are a buy-side analyst. Write a ~120-word, risk-aware rationale for a LEAPS entry. " +
-        "Emphasize trend durability, growth/quality if present, volatility context, and an options liquidity note. " +
-        "Include one caution. No hyperbole.";
+        'You are a buy-side analyst. Write a ~120-word, risk-aware rationale for a LEAPS entry. ' +
+        'Emphasize trend durability, growth/quality if present, volatility context, and an options liquidity note. ' +
+        'Include one caution. No hyperbole.';
       const user = JSON.stringify({
         symbol: r.symbol,
         score: r.score,
         metrics: r.metrics,
         options: r.options,
       });
-      const res = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${env.OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: "gpt-4o-mini",
-          messages: [
-            { role: "system", content: sys },
-            { role: "user", content: `Explain this candidate: ${user}` },
-          ],
-          temperature: 0.3,
-          max_tokens: 220,
-        }),
-      });
-      if (!res.ok) throw new Error(`OpenAI error ${res.status}`);
-      const json: any = await res.json();
-      const text = json.choices?.[0]?.message?.content ?? "";
+      const body = {
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: sys },
+          { role: 'user', content: `Explain this candidate: ${user}` },
+        ],
+        temperature: 0.3,
+        max_tokens: 150,
+      };
+      const json: any = await callGPTWithRetry(env, body);
+      const text = json.choices?.[0]?.message?.content ?? '';
       explained.push({ ...r, rationale: text });
+      await env.leapspicker.put(cacheKey, text, {
+        expirationTtl: 30 * 24 * 60 * 60,
+      });
     } catch {
       explained.push({
         ...r,
         rationale:
-          "Good long-term trend and momentum with reasonable recent volatility. Verify IV rank and option liquidity before entry. Caution: avoid pre-earnings IV spikes.",
+          'Good long-term trend and momentum with reasonable recent volatility. Verify IV rank and option liquidity before entry. Caution: avoid pre-earnings IV spikes.',
       });
     }
   }
   return explained;
 }
+


### PR DESCRIPTION
## Summary
- add exponential backoff for OpenAI calls and respect 429 headers
- limit GPT rationale generation to top N picks and use smaller max_tokens
- cache rationales keyed by symbol and metrics hash

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c1f9675bfc8332bd600b0f412101e7