### PR TITLE
Return /run endpoint immediately and fill GPT rationales asynchronously

### DIFF
--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -24,7 +24,7 @@ export function renderHTML(data: any) {
         <td>${pct(m.mdd1y)} ${badgeMDD(m.mdd1y)}</td>
         <td>${r?.options?.ivRank ?? "—"}</td>
         <td>${r.pass ? badge("PASS", "ok") : badge("WATCH", "warn")}</td>
-        <td class="rationale">${escapeHTML(r.rationale ?? "—")}</td>
+        <td class="rationale">${r.rationale ? escapeHTML(r.rationale) : badge('rationale pending…', 'warn')}</td>
       </tr>`;
     })
     .join("\n");


### PR DESCRIPTION
## Summary
- Use `ctx.waitUntil` so `/run` returns after saving partial results and generates GPT rationales in the background
- Show a "rationale pending…" badge in the dashboard when a rationale is missing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c2b5d8efac8332b36401603a5e52fd